### PR TITLE
Enhance reader UX and add offline downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,15 +50,24 @@
     }
 
     .article {
-      padding: 6px 0;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.5);
-      cursor: pointer;
-      margin-bottom: 10px;
+      background: rgba(255, 255, 255, 0.5);
+      border-radius: 8px;
+      padding: 10px;
+      margin-bottom: 12px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }
 
     .article img {
       border-radius: 6px;
-      margin-bottom: 4px;
+      margin-bottom: 6px;
+      max-width: 100%;
+      display: block;
+    }
+
+    .article-buttons {
+      margin-top: 8px;
+      display: flex;
+      gap: 8px;
     }
 
     .modal {

--- a/preload.js
+++ b/preload.js
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld('api', {
   saveData: (data) => ipcRenderer.invoke('save-data', data),
   fetchFeed: (url) => ipcRenderer.invoke('fetch-feed', url),
   importOpml: (file) => ipcRenderer.invoke('import-opml', file),
+  downloadArticle: (info) => ipcRenderer.invoke('download-article', info),
 });


### PR DESCRIPTION
## Summary
- style article cards for better readability
- show feed titles instead of raw URLs
- render article summaries with Read and Download actions
- fetch full article content in app modal
- add offline download feature

## Testing
- `npm test`
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a26444448321ae397c50352f40a9