### PR TITLE
Improve reader layout and podcast addition

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       border: 1px solid rgba(255, 255, 255, 0.45);
       box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
       padding: 20px 30px;
-      width: 900px;
+      width: min(95vw, 1200px);
       display: flex;
     }
 
@@ -224,7 +224,10 @@
       backdrop-filter: blur(10px);
       padding: 20px;
       border-radius: 8px;
-      max-width: 600px;
+      width: 90%;
+      max-width: 1000px;
+      max-height: 90vh;
+      overflow: auto;
       box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     }
 
@@ -233,8 +236,8 @@
     }
 
     .reader {
-      max-height: 70vh;
-      max-width: 700px;
+      max-height: 80vh;
+      width: 100%;
       margin: 0 auto;
       overflow: auto;
       line-height: 1.6;


### PR DESCRIPTION
## Summary
- make app container expand to nearly full screen
- enlarge reader modal and reader panel
- lock body scrolling when reader is open
- fetch article text with extra fallbacks
- allow podcast addition via iTunes search

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845cf9672c0832187022b1a3751966a