### PR TITLE
Fix podcast search and article display defaults

### DIFF
--- a/main.js
+++ b/main.js
@@ -167,6 +167,18 @@ ipcMain.handle('fetch-podcast', async (_e, url) => {
   }
 });
 
+ipcMain.handle('search-podcasts', async (_e, term) => {
+  try {
+    const res = await fetch(
+      `https://itunes.apple.com/search?media=podcast&limit=5&term=${encodeURIComponent(term)}`
+    );
+    const json = await res.json();
+    return json.results.map(r => ({ title: r.collectionName, feedUrl: r.feedUrl }));
+  } catch {
+    return [];
+  }
+});
+
 ipcMain.handle('import-opml', async (_e, filePath) => {
   ensureFeedDir();
   fs.copyFileSync(filePath, OPML_FILE);

--- a/preload.js
+++ b/preload.js
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('api', {
   saveData: (data) => ipcRenderer.invoke('save-data', data),
   fetchFeed: (url) => ipcRenderer.invoke('fetch-feed', url),
   fetchPodcast: (url) => ipcRenderer.invoke('fetch-podcast', url),
+  searchPodcasts: (term) => ipcRenderer.invoke('search-podcasts', term),
   importOpml: (file) => ipcRenderer.invoke('import-opml', file),
   downloadArticle: (info) => ipcRenderer.invoke('download-article', info),
   downloadEpisode: (info) => ipcRenderer.invoke('download-episode', info),

--- a/renderer.js
+++ b/renderer.js
@@ -44,7 +44,7 @@ let state = {
 let filterText = '';
 let readerMode = false;
 let searchText = '';
-let rangeDays = 1;
+let rangeDays = 7;
 let currentFeed = '*';
 let currentArticles = [];
 let podcastMode = false;
@@ -548,23 +548,16 @@ addPodcastBtn.onclick = async () => {
   if (!input) return;
   let url = input;
   if (!/^https?:/i.test(input)) {
-    try {
-      const res = await fetch(
-        `https://itunes.apple.com/search?media=podcast&limit=5&term=${encodeURIComponent(input)}`
-      );
-      const j = await res.json();
-      if (!j.results.length) {
-        alert('No results');
-        return;
-      }
-      const choice = prompt(
-        j.results
-          .map((r, i) => `${i + 1}: ${r.collectionName}`)
-          .join('\n')
-      );
-      const idx = parseInt(choice, 10) - 1;
-      if (j.results[idx]) url = j.results[idx].feedUrl;
-    } catch {}
+    const results = await window.api.searchPodcasts(input);
+    if (!results.length) {
+      alert('No results');
+      return;
+    }
+    const choice = prompt(
+      results.map((r, i) => `${i + 1}: ${r.title}`).join('\n')
+    );
+    const idx = parseInt(choice, 10) - 1;
+    if (results[idx]) url = results[idx].feedUrl; else return;
   }
   if (!url) return;
   if (state.podcasts.some(p => p.url === url)) {


### PR DESCRIPTION
## Summary
- support podcast search through IPC to avoid CORS
- expose `searchPodcasts` in preload
- use IPC search when adding podcasts
- show articles from the past week by default

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845d682261483218d7e8eecf2b4b575