### PR TITLE
Improve podcast art and offline reading

### DIFF
--- a/main.js
+++ b/main.js
@@ -212,8 +212,19 @@ ipcMain.handle('download-article', async (_e, { url, title }) => {
   ensureOfflineDir();
   const res = await fetch(url);
   const html = await res.text();
+  let content = html;
+  try {
+    const dom = new JSDOM(html, { url });
+    const parsed = new Readability(dom.window.document).parse();
+    if (parsed && parsed.content) content = parsed.content;
+  } catch {}
+  const style =
+    '<style>body{font-family:sans-serif;margin:16px;}img{max-width:100%;}</style>';
   const file = path.join(OFFLINE_DIR, sanitize(title) + '.html');
-  fs.writeFileSync(file, html);
+  fs.writeFileSync(
+    file,
+    `<!DOCTYPE html><meta charset="utf-8">${style}${content}`
+  );
   return file;
 });
 

--- a/renderer.js
+++ b/renderer.js
@@ -208,6 +208,28 @@ function renderPodcasts() {
       };
       reader.readAsDataURL(file);
     };
+    const artBtn = document.createElement('button');
+    artBtn.textContent = 'Add';
+    artBtn.className = 'img-btn';
+    const artInput = document.createElement('input');
+    artInput.type = 'file';
+    artInput.accept = '.png,.jpg,.jpeg';
+    artInput.style.display = 'none';
+    artBtn.onclick = (e) => { e.stopPropagation(); artInput.click(); };
+    artInput.onchange = () => {
+      const file = artInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const dataUrl = reader.result;
+        if (state.episodes[p.url]) {
+          state.episodes[p.url].forEach(ep => { ep.image = dataUrl; });
+        }
+        window.api.saveData(state);
+        if (currentPodcast === p.url) renderEpisodes(filterArticles(state.episodes[p.url] || []));
+      };
+      reader.readAsDataURL(file);
+    };
     const del = document.createElement('button');
     del.textContent = '✖';
     del.className = 'del-feed';
@@ -223,6 +245,8 @@ function renderPodcasts() {
     row.appendChild(btn);
     row.appendChild(imgBtn);
     row.appendChild(input);
+    row.appendChild(artBtn);
+    row.appendChild(artInput);
     row.appendChild(del);
     podcastFeedsDiv.appendChild(row);
   });
@@ -951,6 +975,7 @@ opmlInput.onchange = async () => {
   state.prefs = data.prefs || {};
   state.podcasts = data.podcasts || [];
   state.episodes = data.episodes || {};
+  state.offline = data.offline || [];
   applyTheme();
   applyLayout();
   showPodcastMode(false);


### PR DESCRIPTION
## Summary
- keep offline items across app restarts
- beautify offline saved articles with readability style
- allow applying a single image as episode art for an entire podcast

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e97d7aa88321bf7765ecb9adb0df