### PR TITLE
Enable resizable window and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
       border: 1px solid rgba(255, 255, 255, 0.45);
       box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
       padding: 20px 30px;
-      width: min(95vw, 1200px);
+      width: 95vw;
+      max-width: 1600px;
+      transition: width 0.2s ease;
       display: flex;
     }
 
@@ -52,11 +54,15 @@
       backdrop-filter: blur(8px);
       cursor: pointer;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-      transition: background 0.2s;
+      transition: background 0.2s, transform 0.2s;
     }
 
     button:hover {
       background: rgba(255, 255, 255, 0.6);
+    }
+
+    button:active {
+      transform: scale(0.96);
     }
 
     .active {

--- a/main.js
+++ b/main.js
@@ -103,6 +103,7 @@ function createWindow() {
     height: 800,
     minWidth: 800,
     minHeight: 600,
+    resizable: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,


### PR DESCRIPTION
## Summary
- allow the Electron window to be resized
- make the main layout width responsive
- add small button animation effects

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845f31797d883219f8cb371e9aea781