### PR TITLE
Fix button visibility and window sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
       border: none;
       border-radius: 8px;
       padding: 8px 12px;
-      background: rgba(255, 255, 255, 0.4);
+      background: rgba(255, 255, 255, 0.6);
       backdrop-filter: blur(8px);
       cursor: pointer;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
@@ -59,7 +59,7 @@
     }
 
     button:hover {
-      background: rgba(255, 255, 255, 0.6);
+      background: rgba(255, 255, 255, 0.8);
     }
 
     button:active {
@@ -406,11 +406,11 @@
     }
 
     body[data-theme='dark'] button {
-      background: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.25);
     }
 
     body[data-theme='dark'] button:hover {
-      background: rgba(255, 255, 255, 0.2);
+      background: rgba(255, 255, 255, 0.35);
     }
 
     body[data-theme='dark'] .article {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, shell, screen } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const RSSParser = require('rss-parser');
@@ -98,8 +98,9 @@ function saveData(data) {
 }
 
 function createWindow() {
+  const { width } = screen.getPrimaryDisplay().workAreaSize;
   const win = new BrowserWindow({
-    width: 1200,
+    width: Math.round(width * 0.7),
     height: 800,
     minWidth: 800,
     minHeight: 600,


### PR DESCRIPTION
## Summary
- bump default button opacity so controls are always visible
- adjust dark theme button styles
- size the window to 70% of the screen width at start

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845f7ecb44083218dfe1fcd49b73a89