### PR TITLE
Fix feed prefetch abortion bug

### DIFF
--- a/utils/buildTimeline.js
+++ b/utils/buildTimeline.js
@@ -10,7 +10,10 @@ function buildTimeline(feeds, fetchFn, opts = {}) {
         const { feedTitle, items } = res.value;
         if (feedTitle && !feed.title) feed.title = feedTitle;
         perFeed[url] = items;
-        for (const item of items) timeline.push(item);
+        for (const item of items) {
+          if (feedTitle) item.feedTitle = feedTitle;
+          timeline.push(item);
+        }
       }
     }
     const seen = new Set();


### PR DESCRIPTION
## Summary
- add local abort controller per feed to avoid cancelling other requests
- update favourite feed timeline generator to use new fetch signature
- refetch empty feeds on click and show message when no results
- label articles with source feed title

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684610c935188321abb24fb0dd644770