### PR TITLE
Fix undefined spinner helpers

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -112,6 +112,19 @@ function showNewsMode(on) {
   newsLibBtn.textContent = on ? 'Back to RSS' : 'News Library';
 }
 
+function renderSpinner(el) {
+  el.innerHTML = '<div class="spinner"></div>';
+}
+
+function clearSpinner(el) {
+  const sp = el.querySelector('.spinner');
+  if (sp) sp.remove();
+}
+
+function renderError(el, msg) {
+  el.innerHTML = `<div class="error">${msg}</div>`;
+}
+
 function normalizeFeeds(feeds) {
   return feeds.map(f => (typeof f === 'string' ? { url: f, title: '' } : f));
 }


### PR DESCRIPTION
## Summary
- add simple `renderSpinner`, `clearSpinner`, and `renderError` helpers to avoid runtime errors when switching feeds

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684614c0c9448321b0039f7b8d747103