### PR TITLE
UI: wrap long feed names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Now includes a sidebar feed list with filtering and editable feed names.
 - Local JSON storage of feeds and articles so your subscriptions persist between runs.
 - Sidebar with feed filtering.
 - Edit feed titles inline.
+- Feed names wrap automatically so long titles aren't cut off.
 - Delete feeds with the ✖ button.
 - Add new feeds manually.
 - Dropdown to quickly switch between feeds.

--- a/index.html
+++ b/index.html
@@ -150,9 +150,10 @@
 
     .feed-row button:not(.edit-feed):not(.del-feed) {
       flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      overflow: visible;
+      text-overflow: unset;
+      white-space: normal;
+      word-break: break-word;
     }
 
     .fav-feed {


### PR DESCRIPTION
## Summary
- adjust feed CSS so titles wrap instead of truncating
- note feed name wrapping in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68461bcc2338832189960198440fed9e