### PR TITLE
Implement feed renaming dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
         border: 1px solid rgba(255, 255, 255, 0.45);
         box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
         padding: 20px 30px;
-        width: 95vw;
-        max-width: 1600px;
+        width: auto;
+        max-width: none;
         margin: 0 auto;
         transition: width 0.2s ease;
         display: flex;
@@ -42,7 +42,7 @@
       }
 
     #sidebar {
-      width: 200px;
+      width: auto;
       margin-right: 20px;
       overflow-x: hidden;
     }
@@ -151,9 +151,7 @@
     .feed-row button:not(.edit-feed):not(.del-feed) {
       flex: 1;
       overflow: visible;
-      text-overflow: unset;
-      white-space: normal;
-      word-break: break-word;
+      white-space: nowrap;
     }
 
     .fav-feed {

--- a/renderer.js
+++ b/renderer.js
@@ -160,9 +160,9 @@ function renderFeeds() {
     const edit = document.createElement('button');
     edit.textContent = '✎';
     edit.className = 'edit-feed feed-btn btn';
-    edit.onclick = (e) => {
+    edit.onclick = async (e) => {
       e.stopPropagation();
-      const val = prompt('Feed Name', title);
+      const val = await showPrompt('Feed Name', '', title);
       if (val) {
         feed.title = val;
         scheduleSave();
@@ -593,7 +593,7 @@ function sanitize(text) {
     .replace(/'/g, '&#39;');
 }
 
-function showPrompt(label, placeholder = '') {
+function showPrompt(label, placeholder = '', value = '') {
   return new Promise((res) => {
     dialogContent.innerHTML = `<div><div style="margin-bottom:8px;">${label}</div>` +
       `<input id="promptInput" style="width:100%;margin-bottom:8px;" placeholder="${placeholder}"/>` +
@@ -603,6 +603,7 @@ function showPrompt(label, placeholder = '') {
     dialogModal.style.display = 'flex';
     document.body.style.overflow = 'hidden';
     const input = document.getElementById('promptInput');
+    input.value = value;
     const close = (val) => {
       dialogModal.style.display = 'none';
       document.body.style.overflow = '';


### PR DESCRIPTION
## Summary
- adjust layout rules so feed names do not wrap
- allow editing feed names with custom dialog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68461cbd28288321961edad40b0ed948