### PR TITLE
Add local LLM search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ Now includes a sidebar feed list with filtering and editable feed names.
 - Episode lists show cover art with Play and Download options.
 - Transcripts are stored when available so episodes appear in search results.
 - Organise feeds visually in the News Library with custom logos.
+- AI Search powered by local Ollama models.
+
+## AI Search Setup
+
+1. Install [Ollama](https://ollama.ai) and make sure it is running:
+   ```bash
+   ollama serve
+   ```
+2. Pull a model with good context length. Lightweight options like `phi3` or `llama3` work well:
+   ```bash
+   ollama pull phi3
+   ```
+3. Run RSSimple with `npm start`.
+4. Click the **AI Search** button next to the regular search box.
+5. Pick a model from the dropdown, type your question and hit **Search**.
+
+The app sends each article's headline, a short snippet, any categories, the feed name and the publication date to your selected model. The model replies with the numbers of the most relevant articles so you can open them in reader or normal view.

--- a/index.html
+++ b/index.html
@@ -567,6 +567,7 @@
       </div>
       <div style="display:flex;gap:6px;margin-bottom:8px;align-items:center;">
         <input type="text" id="searchInput" placeholder="Search" style="flex:1" />
+        <button id="aiSearchBtn" class="btn">AI Search</button>
         <select id="rangeSelect">
           <option value="1">Past day</option>
           <option value="3">Past 3 days</option>
@@ -598,6 +599,9 @@
   </div>
   <div class="modal" id="dialogModal">
     <div class="modal-content" id="dialogContent"></div>
+  </div>
+  <div class="modal" id="aiModal">
+    <div class="modal-content" id="aiContent"></div>
   </div>
   <div class="modal" id="audioModal">
     <div class="modal-content" id="audioContent"></div>

--- a/preload.js
+++ b/preload.js
@@ -13,4 +13,6 @@ contextBridge.exposeInMainWorld('api', {
   parseReader: (url) => ipcRenderer.invoke('reader-parse', url),
   openLink: (url) => ipcRenderer.invoke('open-link', url),
   fetchBluesky: (handle) => ipcRenderer.invoke('fetch-bluesky', handle),
+  listOllamaModels: () => ipcRenderer.invoke('list-ollama-models'),
+  ollamaQuery: (opts) => ipcRenderer.invoke('ollama-query', opts),
 });


### PR DESCRIPTION
## Summary
- implement AI Search UI and modal
- integrate with ollama via new IPC handlers
- expose APIs in preload
- hook up AI search button in the renderer
- document AI search capability
- list ollama models and render clickable results from model output
- document detailed setup for AI Search
- include publication dates, feed names and categories in AI search context

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6846ff97b4d483218e2f57861159187a