### PR TITLE
Add feed tag categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Now includes a sidebar feed list with filtering and editable feed names.
 - Local JSON storage of feeds and articles so your subscriptions persist between runs.
 - Sidebar with feed filtering.
 - Edit feed titles inline.
+- Categorize feeds with custom tags.
 - Feed names wrap automatically so long titles aren't cut off.
 - Delete feeds with the ✖ button.
 - Add new feeds manually.

--- a/index.html
+++ b/index.html
@@ -154,6 +154,12 @@
       white-space: nowrap;
     }
 
+    .feed-tags {
+      font-size: 11px;
+      color: var(--fg-dim);
+      margin-left: 4px;
+    }
+
     .fav-feed {
       background: none;
       font-size: 18px;

--- a/main.js
+++ b/main.js
@@ -54,7 +54,8 @@ function parseOPML(filePath) {
         if (node['@_xmlUrl']) {
           arr.push({
             url: node['@_xmlUrl'],
-            title: node['@_title'] || node['@_text'] || node['@_xmlUrl']
+            title: node['@_title'] || node['@_text'] || node['@_xmlUrl'],
+            tags: []
           });
         }
         if (node.outline) arr = arr.concat(collect(node.outline));
@@ -76,6 +77,11 @@ function loadData() {
     if (!data.episodes) data.episodes = {};
     if (!data.offline) data.offline = [];
     if (!data.read) data.read = {};
+    data.feeds = data.feeds.map(f => {
+      if (typeof f === 'string') return { url: f, title: '', tags: [] };
+      if (!f.tags) f.tags = [];
+      return f;
+    });
     if (data.feeds.length === 0 && fs.existsSync(OPML_FILE)) {
       const parsed = parseOPML(OPML_FILE);
       const map = new Map(parsed.map(f => [f.url, f]));


### PR DESCRIPTION
## Summary
- let feeds store tags in `data.json`
- allow assigning tags when adding or editing a feed
- collect existing tags for reuse via a tag prompt
- show tags in the feed list
- document the new tagging feature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684709090684832185ef9f8101ad4c49