### PR TITLE
Improve Ollama context handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ Now includes a sidebar feed list with filtering and editable feed names.
    ollama serve
    ```
 2. Pull a model with good context length. Lightweight options like `phi3` or `llama3` work well:
-   ```bash
-   ollama pull phi3
-   ```
+ ```bash
+  ollama pull phi3
+  ```
 3. Run RSSimple with `npm start`.
+   RSSimple requests an 8k token context window for each search so recent articles
+   fit in one prompt. Models with smaller limits will use their maximum context.
 4. Click the **AI Search** button next to the regular search box.
 5. Pick a model from the dropdown, type your question and hit **Search**.
 

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@ const FEED_DIR = path.join(USER_DIR, 'feeds');
 const OPML_FILE = path.join(FEED_DIR, 'feeds.opml');
 const OFFLINE_DIR = path.join(USER_DIR, 'offline');
 const OLLAMA_URL = 'http://localhost:11434';
+const OLLAMA_CTX = 8192; // tokens to allocate per request
 
 function ensureFeedDir() {
   if (!fs.existsSync(FEED_DIR)) {
@@ -276,7 +277,12 @@ ipcMain.handle('ollama-query', async (_e, { model, prompt }) => {
     const res = await fetch(`${OLLAMA_URL}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, prompt, stream: false })
+      body: JSON.stringify({
+        model,
+        prompt,
+        stream: false,
+        options: { num_ctx: OLLAMA_CTX }
+      })
     });
     const json = await res.json();
     return json.response;


### PR DESCRIPTION
## Summary
- set Ollama context window to 8k tokens so more article metadata fits in a query
- pass the context parameter in `ollama-query`
- document the new context setting in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684716b696b88321aebd9d54ed914cb3