### PR TITLE
Add article summary feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Now includes a sidebar feed list with filtering and editable feed names.
 - "All Recent" tab aggregates articles from the past week.
 - On startup, feeds are prefetched concurrently and "All Recent" loads by default.
 - Reader mode with adjustable font and background color.
+- Summarize articles with your chosen Ollama model.
 - Improved reader formatting and responsive layout.
 - Hidden scrollbars for a cleaner look.
 - Settings modal for customisation.

--- a/index.html
+++ b/index.html
@@ -593,6 +593,7 @@
     <div id="readerBar">
       <button id="toggleReader" class="btn">Reader Mode</button>
       <button id="webMode" class="btn">Web Mode</button>
+      <button id="summaryBtn" class="btn">Summary</button>
       <select id="fontSelect">
         <option value="sans-serif">Sans</option>
         <option value="serif">Serif</option>


### PR DESCRIPTION
## Summary
- add summary button in reader bar
- implement summary modal with Ollama integration
- keep AI search stateless
- document summarization feature

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68472d4423748321b029a91b9657b312