### PR TITLE
Add AI search logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ const DATA_FILE = path.join(USER_DIR, 'data.json');
 const FEED_DIR = path.join(USER_DIR, 'feeds');
 const OPML_FILE = path.join(FEED_DIR, 'feeds.opml');
 const OFFLINE_DIR = path.join(USER_DIR, 'offline');
+const LOG_FILE = path.join(USER_DIR, 'ai-search.log');
 const OLLAMA_URL = 'http://localhost:11434';
 const OLLAMA_CTX = 8192; // tokens to allocate per request
 
@@ -319,4 +320,13 @@ ipcMain.handle('fetch-bluesky', async (_e, handle) => {
   } catch (e) {
     return { error: e.message, items: [] };
   }
+});
+
+ipcMain.handle('log-ai-search', (_e, { query, results }) => {
+  const line = `[${new Date().toISOString()}] ${query} -> ${results}\n`;
+  fs.appendFileSync(LOG_FILE, line);
+});
+
+ipcMain.handle('open-ai-log', () => {
+  shell.openPath(LOG_FILE);
 });

--- a/preload.js
+++ b/preload.js
@@ -15,4 +15,6 @@ contextBridge.exposeInMainWorld('api', {
   fetchBluesky: (handle) => ipcRenderer.invoke('fetch-bluesky', handle),
   listOllamaModels: () => ipcRenderer.invoke('list-ollama-models'),
   ollamaQuery: (opts) => ipcRenderer.invoke('ollama-query', opts),
+  logAiSearch: (info) => ipcRenderer.invoke('log-ai-search', info),
+  openAiLog: () => ipcRenderer.invoke('open-ai-log'),
 });

--- a/renderer.js
+++ b/renderer.js
@@ -856,6 +856,8 @@ async function showAiSearch() {
       } else {
         resultEl.textContent = out.trim();
       }
+      const titles = results.length ? results.map(r => r.title).join('; ') : out.trim();
+      window.api.logAiSearch({ query, results: titles });
     };
     document.getElementById('aiQuery').focus();
   });
@@ -1467,6 +1469,7 @@ settingsBtn.onclick = () => {
     <div>Default Feed: <select id="defaultFeed"><option value="*">All Recent</option>${state.feeds.map(f => `<option value="${f.url}">${f.title || f.url}</option>`).join('')}</select></div>
     <div>Layout: <select id="layoutSel"><option value="sidebar">Sidebar</option><option value="bottom">Bottom Bar</option><option value="gallery">Gallery</option></select></div>
     <div>Text Size: <input type="number" id="textSize" min="12" max="30" value="${state.prefs.textSize || 18}"/></div>
+    <button id="viewLogs">View AI Log</button>
     <button id="closeSettings">Close</button>`;
   settingsModal.style.display = 'flex';
   document.getElementById('setFont').value = state.prefs.font || 'sans-serif';
@@ -1474,6 +1477,9 @@ settingsBtn.onclick = () => {
   document.getElementById('defaultFeed').value = state.prefs.defaultFeed || '*';
   document.getElementById('layoutSel').value = state.prefs.layout || 'sidebar';
   document.getElementById('textSize').value = state.prefs.textSize || 18;
+  document.getElementById('viewLogs').onclick = () => {
+    window.api.openAiLog();
+  };
   document.getElementById('closeSettings').onclick = () => {
     state.prefs.font = document.getElementById('setFont').value;
     state.prefs.bg = document.getElementById('setBg').value;


### PR DESCRIPTION
## Summary
- add ai-search log file and IPC handlers
- expose log helpers in preload
- log AI search queries and results
- open log file from the settings modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68472eb35cdc8321b19dacac8fbc1a0e