### PR TITLE
Improve AI search and summary chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,6 +360,31 @@
       background: transparent !important;
     }
 
+    .chat {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: 200px;
+      overflow: auto;
+      margin-bottom: 8px;
+    }
+
+    .msg {
+      padding: 6px 8px;
+      border-radius: 8px;
+      max-width: 80%;
+    }
+
+    .msg.user {
+      align-self: flex-end;
+      background: rgba(0, 128, 255, 0.2);
+    }
+
+    .msg.ai {
+      align-self: flex-start;
+      background: rgba(0, 0, 0, 0.05);
+    }
+
     #opml {
       display: none;
     }
@@ -481,6 +506,14 @@
 
     body[data-theme='dark'] #readerBar {
       background: rgba(0, 0, 0, 0.4);
+    }
+
+    body[data-theme='dark'] .msg.user {
+      background: rgba(0, 128, 255, 0.3);
+    }
+
+    body[data-theme='dark'] .msg.ai {
+      background: rgba(255, 255, 255, 0.1);
     }
 
     body[data-layout='bottom'] #app {
@@ -614,6 +647,7 @@
     <div class="modal-content" id="audioContent"></div>
   </div>
   <script src="utils/buildTimeline.js"></script>
+  <script src="node_modules/marked/marked.min.js"></script>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "electron": "^29.4.6",
         "fast-xml-parser": "^5.2.5",
         "jsdom": "^24.0.0",
+        "marked": "^9.1.6",
         "rss-parser": "^3.13.0"
       }
     },
@@ -1052,6 +1053,18 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/matcher": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@mozilla/readability": "^0.6.0",
     "electron": "^29.4.6",
     "fast-xml-parser": "^5.2.5",
-    "rss-parser": "^3.13.0",
     "jsdom": "^24.0.0",
-    "@mozilla/readability": "^0.6.0"
+    "marked": "^9.1.6",
+    "rss-parser": "^3.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- fix AI search result handling
- allow pressing Enter to trigger AI search
- add Markdown support with `marked`
- style summary modal as a chat interface

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68473281d5748321817dc98963942e72