### PR TITLE
Improve AI search modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
       display: none;
       justify-content: center;
       align-items: center;
+      pointer-events: auto;
     }
 
     .modal-content {
@@ -309,6 +310,7 @@
       max-height: 90vh;
       overflow: auto;
       box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      pointer-events: auto;
     }
 
     #audioContent {

--- a/renderer.js
+++ b/renderer.js
@@ -808,8 +808,13 @@ function showFeedSearch() {
 
 async function showAiSearch() {
   return new Promise(async (res) => {
+    aiContent.innerHTML = '<div id="aiLoading">Loading models...</div>';
+    aiModal.style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+    const models = await window.api.listOllamaModels();
+    const opts = models.map(m => `<option value="${m}">${m}</option>`).join('');
     aiContent.innerHTML = `<div>` +
-      `<div style="margin-bottom:8px;">Model: <select id="aiModel"></select></div>` +
+      `<div style="margin-bottom:8px;">Model: <select id="aiModel">${opts}</select></div>` +
       `<input id="aiQuery" style="width:100%;margin-bottom:8px;" placeholder="Ask the LLM"/>` +
       `<div style="display:flex;gap:6px;margin-bottom:8px;">` +
       `<button id="aiGo">Search</button><button id="aiClose">Close</button>` +
@@ -817,16 +822,7 @@ async function showAiSearch() {
       `<div id="aiResult" style="max-height:300px;overflow:auto;margin-top:4px;"></div>` +
       `<div style="font-size:12px;margin-top:6px;opacity:0.7;">Ensure Ollama is running. Lightweight models like llama3 or phi3 are recommended.</div>` +
       `</div>`;
-    aiModal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    const models = await window.api.listOllamaModels();
     const sel = document.getElementById('aiModel');
-    models.forEach(m => {
-      const o = document.createElement('option');
-      o.value = m;
-      o.textContent = m;
-      sel.appendChild(o);
-    });
     const close = () => {
       aiModal.style.display = 'none';
       document.body.style.overflow = '';


### PR DESCRIPTION
## Summary
- tweak `.modal` styles so modal content handles pointer events
- show loading message while fetching models for AI search and only render controls once ready

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68473d7029b083218c028804d630343d