### PR TITLE
Switch to toggle-based AI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Now includes a sidebar feed list with filtering and editable feed names.
 3. Run RSSimple with `npm start`.
    RSSimple requests an 8k token context window for each search so recent articles
    fit in one prompt. Models with smaller limits will use their maximum context.
-4. Click the **AI Search** button next to the regular search box.
-5. Pick a model from the dropdown, type your question and hit **Search**.
+4. Toggle the **AI** switch next to the search box.
+5. Pick a model from the dropdown and type your question in the search field.
 
 The app sends each article's headline and publication date along with its feed name and any categories to your selected model. The model replies with the numbers of the most relevant articles so you can open them in reader or normal view.

--- a/index.html
+++ b/index.html
@@ -124,6 +124,66 @@
       border: 1px solid rgba(0, 0, 0, 0.1);
     }
 
+    #searchInput {
+      padding: 6px 12px;
+      border-radius: 20px;
+      border: 1px solid rgba(0, 0, 0, 0.1);
+    }
+
+    #modelSelect,
+    #rangeSelect,
+    #sinceDate,
+    #newsSearch {
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: 1px solid rgba(0, 0, 0, 0.1);
+    }
+
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 34px;
+      height: 20px;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      transition: 0.2s;
+      border-radius: 20px;
+    }
+
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 14px;
+      width: 14px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: 0.2s;
+      border-radius: 50%;
+    }
+
+    .switch input:checked + .slider {
+      background-color: #2196f3;
+    }
+
+    .switch input:checked + .slider:before {
+      transform: translateX(14px);
+    }
+
     #feeds {
       margin-bottom: 10px;
       max-height: 60vh;
@@ -608,7 +668,14 @@
       </div>
       <div style="display:flex;gap:6px;margin-bottom:8px;align-items:center;">
         <input type="text" id="searchInput" placeholder="Search" style="flex:1" />
-        <button id="aiSearchBtn" class="btn">AI Search</button>
+        <span style="display:flex;align-items:center;gap:4px;">
+          <span>AI</span>
+          <label class="switch">
+            <input type="checkbox" id="aiToggle" />
+            <span class="slider"></span>
+          </label>
+        </span>
+        <select id="modelSelect" style="display:none"></select>
         <select id="rangeSelect">
           <option value="1">Past day</option>
           <option value="3">Past 3 days</option>


### PR DESCRIPTION
## Summary
- remove AI Search button and comment out modal-based search
- add AI toggle and model dropdown next to main search bar
- implement inline AI search when toggle is active
- update README instructions
- round search bar and add custom toggle UI

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68473f073dbc8321a7338082d42aedff