### PR TITLE
Enhance AI tools and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,6 +674,7 @@
       <div style="display:flex;gap:6px;margin-bottom:8px;align-items:center;">
         <input type="text" id="searchInput" placeholder="Search" style="flex:1" />
         <button id="searchBtn" class="btn" title="Search">🔍</button>
+        <button id="dailySummaryBtn" class="btn">Daily Summary</button>
         <span style="display:flex;align-items:center;gap:4px;">
           <span>AI</span>
           <label class="switch">
@@ -702,6 +703,7 @@
       <button id="toggleReader" class="btn">Reader Mode</button>
       <button id="webMode" class="btn">Web Mode</button>
       <button id="summaryBtn" class="btn">Summary</button>
+      <button id="backBtn" class="btn" style="display:none;">Back</button>
       <select id="fontSelect">
         <option value="sans-serif">Sans</option>
         <option value="serif">Serif</option>

--- a/main.js
+++ b/main.js
@@ -274,6 +274,8 @@ ipcMain.handle('list-ollama-models', async () => {
 });
 
 ipcMain.handle('ollama-query', async (_e, { model, prompt }) => {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), 30000);
   try {
     const res = await fetch(`${OLLAMA_URL}/api/generate`, {
       method: 'POST',
@@ -283,12 +285,15 @@ ipcMain.handle('ollama-query', async (_e, { model, prompt }) => {
         prompt,
         stream: false,
         options: { num_ctx: OLLAMA_CTX }
-      })
+      }),
+      signal: controller.signal
     });
     const json = await res.json();
     return json.response;
   } catch (e) {
     return 'Error: ' + e.message;
+  } finally {
+    clearTimeout(id);
   }
 });
 


### PR DESCRIPTION
## Summary
- add Daily Summary button and chat-based summary UI
- add back button when opening links in reader
- intercept article links to open in-app webview
- add timeout to Ollama queries

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684746c37ee48321be1412f882d5638d