### PR TITLE
Fix initial load for recent feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,6 +300,12 @@
       margin-top: 4px;
     }
 
+    .pubdate {
+      font-size: 14px;
+      opacity: 0.7;
+      margin: 8px 0;
+    }
+
     #newsLibrary {
       display: flex;
       flex-wrap: wrap;
@@ -779,6 +785,7 @@
       <button id="toggleReader" class="btn">Reader Mode</button>
       <button id="webMode" class="btn">Web Mode</button>
       <button id="summaryBtn" class="btn">Summary</button>
+      <button id="unsubBtn" class="btn">Unsubscribe</button>
       <button id="backBtn" class="btn" style="display:none;">Back</button>
       <select id="fontSelect">
         <option value="sans-serif">Sans</option>


### PR DESCRIPTION
## Summary
- load the "Most Recent" timeline on app startup
- refresh the Most Recent feed whenever navigating back to it
- keep user's place when other feeds refresh
- better article date formatting
- show date and unsubscribe option in article reader

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6847615955ec832186b042844edf47af