### PR TITLE
Implement font upload and reader toolbar fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,10 +349,11 @@
     }
 
     #readerBar {
-      position: absolute;
+      position: fixed;
       bottom: 10px;
       left: 50%;
       transform: translateX(-50%);
+      z-index: 10;
       display: flex;
       gap: 8px;
       background: rgba(255, 255, 255, 0.5);
@@ -797,6 +798,8 @@
         <option value="sans-serif">Sans</option>
         <option value="serif">Serif</option>
       </select>
+      <button id="uploadFontBtn" class="btn">Upload Font</button>
+      <input type="file" id="fontFile" accept=".ttf,.otf,.woff,.woff2" style="display:none" />
       <input type="color" id="bgColor" value="#ffffff" />
     </div>
   </div>

--- a/preload.js
+++ b/preload.js
@@ -19,4 +19,7 @@ contextBridge.exposeInMainWorld('api', {
   openAiLog: () => ipcRenderer.invoke('open-ai-log'),
   logMain: (info) => ipcRenderer.invoke('log-main', info),
   openMainLog: () => ipcRenderer.invoke('open-main-log'),
+  listFonts: () => ipcRenderer.invoke('list-fonts'),
+  addFont: (file) => ipcRenderer.invoke('add-font', file),
+  fontPath: (name) => ipcRenderer.invoke('font-path', name)
 });


### PR DESCRIPTION
## Summary
- keep reader toolbar fixed to the modal bottom
- allow fonts to be uploaded and saved
- load custom fonts in both reader and settings
- ensure articles without dates remain visible

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684769a1d1b883218d4753f82e94f531