### PR TITLE
Add SearxNG-powered 'Ask Simpli' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,21 @@ Now includes a sidebar feed list with filtering and editable feed names.
 - Episode lists show cover art with Play and Download options.
 - Transcripts are stored when available so episodes appear in search results.
 - Organise feeds visually in the News Library with custom logos.
-- AI Search powered by local Ollama models.
-- Search results are now clickable even when the model replies with titles.
+- "Ask Simpli" dialog with optional web search via SearxNG and Ollama models.
+- SearxNG instance can be changed in the Settings panel.
 
-## AI Search Setup
+## Ask Simpli
 
 1. Install [Ollama](https://ollama.ai) and make sure it is running:
    ```bash
    ollama serve
    ```
 2. Pull a model with good context length. Lightweight options like `phi3` or `llama3` work well:
- ```bash
-  ollama pull phi3
-  ```
+   ```bash
+   ollama pull phi3
+   ```
 3. Run RSSimple with `npm start`.
-   RSSimple requests an 8k token context window for each search so recent articles
-   fit in one prompt. Models with smaller limits will use their maximum context.
-4. Toggle the **AI** switch next to the search box.
-5. Pick a model from the dropdown and type your question in the search field.
+4. Click **Ask Simpli** to open the dialog. Choose your model and type a question.
+5. Enable **Web search** to include SearxNG results using the instance set in Settings.
 
-The app sends each article's headline and publication date along with its feed name and any categories to your selected model. The model replies with the numbers of the most relevant articles so you can open them in reader or normal view.
+Ask Simpli fetches today's article list and (when enabled) a short set of web results. The Ollama model replies conversationally, explaining the steps it took and citing which websites were used from SearxNG.

--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
       border-radius: 20px;
     }
 
-    #modelSelect,
     #rangeSelect,
     #sinceDate,
     #newsSearch {
@@ -768,15 +767,7 @@
       <div style="display:flex;gap:6px;margin-bottom:8px;align-items:center;">
         <input type="text" id="searchInput" placeholder="Search" style="flex:1" />
         <button id="searchBtn" class="btn" title="Search">🔍</button>
-        <button id="dailySummaryBtn" class="btn">Daily Summary</button>
-        <span style="display:flex;align-items:center;gap:4px;">
-          <span>AI</span>
-          <label class="switch">
-            <input type="checkbox" id="aiToggle" />
-            <span class="slider"></span>
-          </label>
-        </span>
-        <select id="modelSelect" style="display:none"></select>
+        <button id="askBtn" class="btn">Ask Simpli</button>
         <select id="rangeSelect">
           <option value="1">Past day</option>
           <option value="3">Past 3 days</option>

--- a/preload.js
+++ b/preload.js
@@ -22,5 +22,6 @@ contextBridge.exposeInMainWorld('api', {
   listFonts: () => ipcRenderer.invoke('list-fonts'),
   addFont: (file) => ipcRenderer.invoke('add-font', file),
   fontPath: (name) => ipcRenderer.invoke('font-path', name),
-  removeFont: (name) => ipcRenderer.invoke('remove-font', name)
+  removeFont: (name) => ipcRenderer.invoke('remove-font', name),
+  searxSearch: (opts) => ipcRenderer.invoke('searx-search', opts)
 });


### PR DESCRIPTION
## Summary
- remove old AI search UI and logic
- add "Ask Simpli" button with optional web search
- integrate SearxNG search via new IPC handler
- allow configuring SearxNG instance in Settings
- update documentation for Ask Simpli feature
- improve Ask Simpli replies by showing web search steps and citing sources

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684771af17908321a111f89300989212