### PR TITLE
Fix Ask Simpli article retrieval

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -181,11 +181,15 @@ function normalizeFeeds(feeds) {
 }
 
 async function showAskSimpli() {
-  const today = new Date().toISOString().slice(0, 10);
+  await prefetchAll(false);
+  const since = Date.now() - 86400000;
   let list = Object.values(state.articles).flat();
-  list = list.filter(a => (a.isoDate || a.pubDate || '').startsWith(today));
+  list = list.filter(a => {
+    const d = new Date(a.isoDate || a.pubDate || 0).getTime();
+    return d >= since;
+  });
   if (!list.length) {
-    alert('No articles from today');
+    alert('No recent articles');
     return;
   }
   const text = list


### PR DESCRIPTION
## Summary
- refresh feeds before opening Ask Simpli and check for articles from the last 24h

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684775c426a083218996b2dc53f9e62e