### PR TITLE
Fix all recent feed and make Ask Simpli contextual

### DIFF
--- a/utils/buildTimeline.js
+++ b/utils/buildTimeline.js
@@ -7,9 +7,10 @@ function buildTimeline(feeds, fetchFn, opts = {}) {
       const url = feed.url || feed;
       const res = results[i];
       if (res.status === 'fulfilled' && !res.value.error) {
-        const { feedTitle, items } = res.value;
+        const { feedTitle, items, image } = res.value;
         if (feedTitle && !feed.title) feed.title = feedTitle;
-        perFeed[url] = items;
+        if (image && !feed.image) feed.image = image;
+        perFeed[url] = { items, image };
         for (const item of items) {
           if (feedTitle) item.feedTitle = feedTitle;
           timeline.push(item);


### PR DESCRIPTION
## Summary
- buildTimeline now tracks images and returns them with items
- use buildTimeline in prefetchAll to fetch all feeds reliably
- update favorite feeds aggregator accordingly
- improve Ask Simpli so it uses articles from the current feed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684776a414488321af66eafd364040b5